### PR TITLE
license year 변경 (2022 -> 2023)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 가짜연구소 (Pseudo Lab)
+Copyright (c) 2023 가짜연구소 (Pseudo Lab)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -3,6 +3,7 @@
 title : Data Engineering for Everybody
 author: PseudoLab
 logo: 'PseudoLab_logo.png'
+copyright: 2023
 
 # Short description about the book
 description: >-


### PR DESCRIPTION
- 이전 스크럼 때 페이지 하단에 나오는 연도(2022 -> 2023) 변경하자는 의견이 나왔던걸로 기억해서 변경해봤습니다!
- ~(하지만 jupyter book 로컬 테스트 해보니 2022으로 보여서ㅠ 우선 draft로 PR 올려둡니다!)~
예신님 코멘트 덕분에 해결했습니다 감사합니다 :)
